### PR TITLE
Replaced variable with no reference with $request

### DIFF
--- a/Model/Client/RestClient.php
+++ b/Model/Client/RestClient.php
@@ -126,7 +126,7 @@ class RestClient extends RemoteClient implements RestClientInterface
             ': ' .
             $this->getUrlFromUri($request) .
             ' || StatusCode: ' .
-            $rawResponse->getStatusCode()
+            $response->getStatusCode()
         );
     }
 }


### PR DESCRIPTION
The variable without reference was causing issues when there was any error during  remote connection.